### PR TITLE
Suggestions for Common/Localizable.strings

### DIFF
--- a/de.lproj/Common/Localizable.strings
+++ b/de.lproj/Common/Localizable.strings
@@ -70,8 +70,8 @@
     <string>Unbekannter Fehler.</string>
     <key>We are a tiny two-person company (sometimes three) that loves creating exceptional apps for iOS and the Mac.
 Paul codes in Texas and Mark designs in California.</key>
-    <string>Wir sind eine kleine zwei (manchmal auch drei) Mann große Firma, die es liebt außergewöhnliche Apps für iOS und Mac zu schreiben.
-Paul programmiert in Texas und Mark designed in Kalifornien.</string>
+<string>Wir sind ein kleines Zwei-, manchmal auch Drei-Personen-Unternehmen, welches es liebt außergewöhnliche Apps für iOS und den Mac zu erschaffen.
+Paul programmiert in Texas und Mark designt in Kalifornien.</string>
     <key>Which account do you want to follow %@ with?</key>
     <string>Mit welchem Account möchten Sie %@ folgen?</string>
     <key>Yesterday at %@</key>

--- a/de.lproj/Common/Localizable.strings
+++ b/de.lproj/Common/Localizable.strings
@@ -29,7 +29,7 @@
     <key>Close</key>
     <string>Schließen</string>
     <key>Couldn’t parse JSON data.</key>
-    <string>Konnte JSON Daten nicht lesen.</string>
+    <string>Konnte JSON-Daten nicht lesen.</string>
     <key>Dumb Quotes</key>
     <string>Senkrechte Anführungszeichen</string>
     <key>FOLLOW US ON TWITTER</key>

--- a/de.lproj/Common/Localizable.strings
+++ b/de.lproj/Common/Localizable.strings
@@ -39,7 +39,7 @@
     <key>Leave %@?</key>
     <string>%@ verlassen?</string>
     <key>Network Connection Busy</key>
-    <string>Netzwerkverbindung beschäftigt</string>
+    <string>Netzwerkverbindung besetzt</string>
     <key>Now</key>
     <string>Jetzt</string>
     <key>OFF</key>


### PR DESCRIPTION
# Suggestions for #3 Common/Localizable.strings

I noticed a few things within this file (see each individual commit, or all commits combined listed below).
## Couldn’t parse JSON data. [cf. 1fed5dd]

_Suggestion:_ Konnte JSON-Daten nicht lesen.
_Explanation:_ Small correction: JSON is—in my opinion—part of the noun, not an adjective; therefore the hyphen is needed.
## Network Connection Busy [cf. 2673393]

_Suggestion:_ Netzwerkverbindung besetzt
_Explanation:_ Correction: Less literal but semantically more correct translation, in my opinion. «beschäftigt» partially implies that the connection is actively doing something, whereas «besetzt» merely observes the occupied state of the connection.
## We are a tiny two-person company […] [cf. b236387]

_Suggestion:_ Wir sind ein kleines Zwei-, manchmal auch Drei-Personen-Unternehmen, welches es liebt außergewöhnliche Apps für iOS und den Mac zu erschaffen.
Paul programmiert in Texas und Mark designt in Kalifornien.
_Explanation:_ Corrections/changes:
1. «designs» (3rd person singular) has to be «designt» in German.
2. «Zwei-Personen» (two-person) is preferable to «Zwei-Mann» (two-men).
3. «Unternehmen» (company) is more generic than «Firma» (firm).
4. «erschaffen» resembles «create» more closely than «schreiben» (write); although I'm not entirely happy with it either.
5. Added the definite article before «Mac».
