### PR TITLE
Translated missing strings

### DIFF
--- a/de.lproj/Calcbot/App/Localizable.stringsMissing
+++ b/de.lproj/Calcbot/App/Localizable.stringsMissing
@@ -3,22 +3,22 @@
 <plist version="1.0">
   <dict>
     <key>From Unit</key>
-    <string>From Unit</string>
+    <string>Von Einheit</string>
     <key>Main</key>
-    <string>Main</string>
+    <string>Hauptfenster</string>
     <key>Pre-define 4 conversions for quick access
 on your Apple Watch.</key>
-    <string>Pre-define 4 conversions for quick access
-on your Apple Watch.</string>
+    <string>Definiere 4 Umrechnungen für den schnellen Zugriff
+auf Deiner Apple Watch.</string>
     <key>To Unit</key>
-    <string>To Unit</string>
+    <string>Zu Einheit</string>
     <key>Upgrade to Pro to customize the conversions
 on your Apple Watch.</key>
-    <string>Upgrade to Pro to customize the conversions
-on your Apple Watch.</string>
+    <string>Upgrade auf Pro, um die Umrechnungen
+auf Deiner Apple Watch anzupassen.</string>
     <key>Watch</key>
     <string>Watch</string>
     <key>You may define your own title. Try to keep it under 8 characters to avoid truncation.</key>
-    <string>You may define your own title. Try to keep it under 8 characters to avoid truncation.</string>
+    <string>Du kannst Deinen eigenen Titel festlegen. Versuche ihn unter 8 Zeichen zu halten, damit er nicht abgeschnitten wird.</string>
   </dict>
 </plist>


### PR DESCRIPTION
I'm not sure about the following translations:
- Main -> Hauptfenster ('Main' is translated to the prefix 'Haupt-'; 'Hauptfenster' means 'Main window')
- Watch -> Watch (if you refer to the Apple Watch, this translation is right; if you refer to a normal watch, it should be translated to 'Uhr')
